### PR TITLE
Home: news article publish date

### DIFF
--- a/lib/ui/pages/home/widgets/news_item_widget.dart
+++ b/lib/ui/pages/home/widgets/news_item_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 
 import '../../../../domain/entities/news_entity.dart';
 
@@ -87,6 +88,16 @@ class _NewsItemWidgetState extends State<NewsItemWidget> {
                       ),
                       if (widget.constraints.maxWidth >= 800)
                         Text(widget.news.summary),
+                      Padding(
+                        padding: const EdgeInsets.only(top: 8.0),
+                        child: Text(
+                          DateFormat('MMMM d, y')
+                              .format(widget.news.publishedAt!),
+                          style: TextStyle(
+                            fontSize: 13,
+                          ),
+                        ),
+                      ),
                     ],
                   ),
                 ),

--- a/lib/ui/pages/home/widgets/news_item_widget.dart
+++ b/lib/ui/pages/home/widgets/news_item_widget.dart
@@ -56,11 +56,13 @@ class _NewsItemWidgetState extends State<NewsItemWidget> {
           ),
         ),
         Positioned(
-          top: widget.constraints.maxHeight / 1.3,
+          bottom: 50,
           left: widget.constraints.maxWidth >= 800 ? 120 : 0,
           child: ConstrainedBox(
             constraints: BoxConstraints(
-              maxWidth: widget.constraints.maxWidth / 1.5,
+              maxWidth: widget.constraints.maxWidth >= 800
+                  ? 500
+                  : widget.constraints.maxWidth / 1.2,
             ),
             child: AnimatedContainer(
               duration: const Duration(milliseconds: 200),
@@ -83,7 +85,8 @@ class _NewsItemWidgetState extends State<NewsItemWidget> {
                           fontSize: 20,
                         ),
                       ),
-                      Text(widget.news.summary),
+                      if (widget.constraints.maxWidth >= 800)
+                        Text(widget.news.summary),
                     ],
                   ),
                 ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -137,6 +137,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.1+1"
+  intl:
+    dependency: "direct main"
+    description:
+      name: intl
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.17.0"
   matcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,6 +30,7 @@ dependencies:
   flutter_modular_test: ^1.0.1
   flutter_svg: ^0.22.0
   infinite_scroll_pagination: ^3.0.1+1
+  intl: ^0.17.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Closes #27 

### What?
Included publish date in the news article cards in the home screen.

### Screenshot
![image](https://user-images.githubusercontent.com/30700205/123725836-322c6980-d865-11eb-9937-a7f82c5c83ac.png)
